### PR TITLE
Update Dockerfile with changes to support real entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,15 @@ ARG CLI_BUILD="194"
 ARG CLI_VERSION="0.16.3"
 ARG CLI_TIMESTAMP="20191024181014"
 
-WORKDIR /tmp/aptible-cli
-RUN curl -fsSLO "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/${CLI_BUILD}/pkg/aptible-toolbelt_${CLI_VERSION}%2B${CLI_TIMESTAMP}%7Eubuntu.16.04-1_amd64.deb" && \
-      dpkg -i "aptible-toolbelt_${CLI_VERSION}%2B${CLI_TIMESTAMP}%7Eubuntu.16.04-1_amd64.deb"  && \
-      rm "aptible-toolbelt_${CLI_VERSION}%2B${CLI_TIMESTAMP}%7Eubuntu.16.04-1_amd64.deb"
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		jq \
+    && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /action
-COPY entrypoint.sh entrypoint.sh
-ENTRYPOINT ["./entrypoint.sh"]
+WORKDIR /tmp/aptible-cli
+RUN CLI_FILE="aptible-toolbelt_${CLI_VERSION}%2B${CLI_TIMESTAMP}%7Eubuntu.16.04-1_amd64.deb" && \
+    curl -fsSLO "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/${CLI_BUILD}/pkg/${CLI_FILE}" && \
+    dpkg -i "${CLI_FILE}"  && \
+    rm "${CLI_FILE}"
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
- Adds `jq` that is used in our entrypoint
- Uses a variable to shorten the lines
- Does not rely on WORKDIR for the entrypoint script. GitHub actions
  overwrites this per [their docs](https://help.github.com/en/actions/building-actions/dockerfile-support-for-github-actions#workdir)

To test locally, we have to ignore the entrypoint so
```bash
docker build -t aptible-cli .
docker run -it --rm --entrypoint "" aptible-cli sh -c 'curl -fSs https://jsonplaceholder.typicode.com/todos/1 | jq -c ".title"'
```