### PR TITLE
Make action fail if app not found

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,8 +31,8 @@ aptible login \
   --password "$INPUT_PASSWORD"
 
 if ! APTIBLE_OUTPUT_FORMAT=json aptible apps | jq -e ".[] | select(.handle == \"$INPUT_APP\") | select(.environment.handle == \"$INPUT_ENVIRONMENT\")" > /dev/null; then
-  echo "$0: skip (could not find app $INPUT_APP)" >&2
-  exit 0
+  echo "Could not find app $INPUT_APP in $INPUT_ENVIRONMENT" >&2
+  exit 1
 fi
 
 aptible deploy --environment "$INPUT_ENVIRONMENT" \


### PR DESCRIPTION
The original CI/CD job we transitioned this from returned success so we wouldn't fail out the job and prevent tests from "passing". This is a pure "deployment" step so we should fail it out if the app cannot be deployed successfully.