### PR TITLE
adding private registry authentication details to aptible deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM buildpack-deps:xenial-curl
 
-ARG CLI_BUILD="194"
-ARG CLI_VERSION="0.16.3"
-ARG CLI_TIMESTAMP="20191024181014"
+ARG CLI_BUILD="217"
+ARG CLI_VERSION="0.16.7"
+ARG CLI_TIMESTAMP="20200812001454"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		jq \
+		u2f-host \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp/aptible-cli
-RUN CLI_FILE="aptible-toolbelt_${CLI_VERSION}%2B${CLI_TIMESTAMP}%7Eubuntu.16.04-1_amd64.deb" && \
+RUN CLI_FILE="aptible-toolbelt_${CLI_VERSION}%2B${CLI_TIMESTAMP}~ubuntu.16.04-1_amd64.deb" && \
     curl -fsSLO "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/${CLI_BUILD}/pkg/${CLI_FILE}" && \
     dpkg -i "${CLI_FILE}"  && \
     rm "${CLI_FILE}"

--- a/README.md
+++ b/README.md
@@ -25,5 +25,24 @@ aptible config:set \
 * `environment` - specifies App to be deployed
 * `app` - specifies App to be deployed
 * `docker_img` - the name of the image you’d like to deploy, including its repository and tag
+* `private_registry_username` - the username for the private registry to pull a docker image from
+* `private_registry_password` - the password for the private registry to pull a docker image from
 
-## Example workflow using the image
+## Example github actions usage
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Deploy to Aptible
+            uses: aptible/aptible-deploy-action@master
+            with:
+              username: <aptible username>
+              password: <aptible password>
+              environment: <environment name>
+              app: <app name>
+              docker_img: <docker image name>
+              private_registry_username: <username>
+              private_registry_password: <password>
+```

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,12 @@ inputs:
   docker_img: 
     description: 'Docker image'
     required: True
+  private_registry_username:
+    description: 'Private Registry Username'
+    required: False
+  private_registry_password:
+    description: 'Private Registry Password'
+    required: False
 outputs:
    status:
     description: "The Success/Failure of the action"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,4 +36,7 @@ if ! APTIBLE_OUTPUT_FORMAT=json aptible apps | jq -e ".[] | select(.handle == \"
 fi
 
 aptible deploy --environment "$INPUT_ENVIRONMENT" \
-               --app "$INPUT_APP" --docker-image "$INPUT_DOCKER_IMG"
+               --app "$INPUT_APP" \
+               --docker-image "$INPUT_DOCKER_IMG" \
+               --private-registry-username "$INPUT_PRIVATE_REGISTRY_USERNAME" \
+               --private-registry-password "$INPUT_PRIVATE_REGISTRY_PASSWORD"


### PR DESCRIPTION
upgrade aptible package to 0.16.7 in order to support private registry authentication
updating README to inculde a github actions example

Including the aptible private registry into the one command makes the github actions easier to work with, and less passing around of variables within the actions.