### PR TITLE
Allow configuration variables to be set during deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following inputs can be used as `step.with` keys
 
 - `private_registry_username` - the username for the private registry to pull a docker image from
 - `private_registry_password` - the password for the private registry to pull a docker image from
+- `config_variables` - a space separated list of key=value pairs to set as config variables on the app during deployment
 
 ## Outputs
 
@@ -51,6 +52,7 @@ jobs:
           docker_img: <docker image name>
           private_registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
           private_registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          config_variables: KEY1=value1 KEY2=value2
 ```
 
 ## Example with Container Build and Docker Hub
@@ -99,4 +101,5 @@ jobs:
           docker_img: ${{ env.IMAGE_NAME }}
           private_registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
           private_registry_password: ${{ secrets.DOCKERHUB_TOKEN }}
+          config_variables: RELEASE_SHA=${{ github.sha }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   private_registry_password:
     description: 'Private Registry Password'
     required: False
+  config_variables:
+    description: 'Configuration variables to set on deploy'
+    required: False
 outputs:
    status:
     description: "The Success/Failure of the action"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,4 +39,5 @@ aptible deploy --environment "$INPUT_ENVIRONMENT" \
                --app "$INPUT_APP" \
                --docker-image "$INPUT_DOCKER_IMG" \
                --private-registry-username "$INPUT_PRIVATE_REGISTRY_USERNAME" \
-               --private-registry-password "$INPUT_PRIVATE_REGISTRY_PASSWORD"
+               --private-registry-password "$INPUT_PRIVATE_REGISTRY_PASSWORD" \
+               ${INPUT_CONFIG_VARIABLES}


### PR DESCRIPTION
Here we add a new optional parameter to the action so that users may set aptible config variables during the deploy action. This is useful for cases where config values might depend on information present during the Github workflow that is calling the action (for example, the git sha used to build the image).

Example usage is added to the documentation as well.