### PR TITLE
Update entrypoint.sh to allow spaces in variable values

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,4 +40,4 @@ aptible deploy --environment "$INPUT_ENVIRONMENT" \
                --docker-image "$INPUT_DOCKER_IMG" \
                --private-registry-username "$INPUT_PRIVATE_REGISTRY_USERNAME" \
                --private-registry-password "$INPUT_PRIVATE_REGISTRY_PASSWORD" \
-               ${INPUT_CONFIG_VARIABLES}
+               "${INPUT_CONFIG_VARIABLES}"


### PR DESCRIPTION
If you set the value `SSL_PROTOCOLS_OVERRIDE='TLS1.2 PFS'`, this fails because of incorrect whitespace parsing. With the quotes added, the whitespaces will be respected as non-tokenizing.

I verified this fix works on my fork at https://github.com/marketplace/actions/deploy-to-aptible-patch