### PR TITLE
chore: update latest tags to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Deploy to Aptible
-      uses: aptible/aptible-deploy-action@v2
+      uses: aptible/aptible-deploy-action@v4
       with:
         type: git
         app: <app name>
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Deploy to Aptible
-      uses: aptible/aptible-deploy-action@v2
+      uses: aptible/aptible-deploy-action@v4
       with:
         type: docker 
         app: <app name>
@@ -165,7 +165,7 @@ jobs:
         tags: ${{ env.IMAGE_NAME }}
 
     - name: Deploy to Aptible
-      uses: aptible/aptible-deploy-action@v2
+      uses: aptible/aptible-deploy-action@v4
       with:
         type: docker 
         app: ${{ env.APTIBLE_APP }}

--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,4 @@ outputs:
 runs:
   using: 'docker'
   # image: 'Dockerfile'
-  image: docker://quay.io/aptible/aptible-deploy-action:v2
+  image: docker://quay.io/aptible/aptible-deploy-action:v4


### PR DESCRIPTION
Since we had to cut releases to revert previous major release, this PR updates references to `v4`.

https://quay.io/repository/aptible/aptible-deploy-action?tab=tags