### PR TITLE
Provide a graceful fallback for git metadata retrieval

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,9 +46,9 @@ fi
 REPO_URL="https://github.com/$GITHUB_REPOSITORY"
 COMMIT_SHA="$GITHUB_SHA"
 COMMIT_URL="$REPO_URL/commit/$COMMIT_SHA"
-COMMIT_DATE=$(git log -1 --date=iso-strict --format="%ad")
+COMMIT_DATE=$(git log -1 --date=iso-strict --format="%ad" 2>/dev/null || printf '')
 GIT_CONFIG_VARIABLES="APTIBLE_GIT_COMMIT_SHA=$COMMIT_SHA APTIBLE_GIT_REPOSITORY_URL=$REPO_URL APTIBLE_GIT_REF=$BRANCH APTIBLE_GIT_COMMIT_URL=$COMMIT_URL APTIBLE_GIT_COMMIT_DATE=$COMMIT_DATE"
-COMMIT_MESSAGE=$(git log -n 1 --pretty=format:'%s%n')
+COMMIT_MESSAGE=$(git log -n 1 --pretty=format:'%s%n' 2>/dev/null || printf '')
 
 if [ "$INPUT_TYPE" == "git" ]; then
   if [ "$INPUT_GIT_REMOTE" == "primetime.aptible.com" ]; then


### PR DESCRIPTION
This PR fixes an issue where the action would fail if the user has not checked out their code prior to initiating the deployment.

If the repo has not been checked out, the `git` commands would fail with:

```
fatal: not a git repository (or any of the parent directories): .git
```

This PR hides the error and falls back to empty strings for values that can't be retrieved.