### PR TITLE
chore: point at latest cli s3 url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM buildpack-deps:xenial-curl
 
-ARG CLI_BUILD="217"
-ARG CLI_VERSION="0.16.7"
-ARG CLI_TIMESTAMP="20200812001454"
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		jq \
 		u2f-host \
@@ -12,8 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp/aptible-cli
-RUN CLI_FILE="aptible-toolbelt_${CLI_VERSION}%2B${CLI_TIMESTAMP}~ubuntu.16.04-1_amd64.deb" && \
-    curl -fsSLO "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/${CLI_BUILD}/pkg/${CLI_FILE}" && \
+RUN CLI_FILE="aptible-toolbelt_latest_ubuntu-1604_amd64.deb" && \
+    curl -fsSLO "https://omnibus-aptible-toolbelt.s3.us-east-1.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/${CLI_FILE}" && \
     dpkg -i "${CLI_FILE}"  && \
     rm "${CLI_FILE}"
 


### PR DESCRIPTION
This change updates our Dockerfile to pull whatever the latest CLI version is at build time.  This makes it easier for us to cut a new releaase of the gha with the latest cli version.