### PR TITLE
Update Git to ignore directory warnings

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ if [ "$INPUT_TYPE" == "git" ]; then
   REMOTE_URL="root@$INPUT_GIT_REMOTE:$INPUT_ENVIRONMENT/$INPUT_APP.git"
   git remote add aptible ${REMOTE_URL}
   REMOTE_BRANCH="deploy-$(date "+%s")"
-  GIT_SSH_COMMAND="ssh -o SendEnv=ACCESS_TOKEN -o PubkeyAuthentication=no -o UserKnownHostsFile=./known_hosts -p 43022" git push aptible "$BRANCH:$REMOTE_BRANCH"
+  GIT_SSH_COMMAND="ssh -o SendEnv=ACCESS_TOKEN -o PubkeyAuthentication=no -o UserKnownHostsFile=./known_hosts -p 43022" git -c safe.directory='*' push aptible "$BRANCH:$REMOTE_BRANCH"
 
   aptible deploy --environment "$INPUT_ENVIRONMENT" \
                  --app "$INPUT_APP" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,9 +61,10 @@ if [ "$INPUT_TYPE" == "git" ]; then
   fi
   export ACCESS_TOKEN=$(cat "$HOME/.aptible/tokens.json" | jq ".[\"$APTIBLE_AUTH_ROOT_URL\"]" -r)
   REMOTE_URL="root@$INPUT_GIT_REMOTE:$INPUT_ENVIRONMENT/$INPUT_APP.git"
+  git config --global --add safe.directory /github/workspace
   git remote add aptible ${REMOTE_URL}
   REMOTE_BRANCH="deploy-$(date "+%s")"
-  GIT_SSH_COMMAND="ssh -o SendEnv=ACCESS_TOKEN -o PubkeyAuthentication=no -o UserKnownHostsFile=./known_hosts -p 43022" git -c safe.directory='*' push aptible "$BRANCH:$REMOTE_BRANCH"
+  GIT_SSH_COMMAND="ssh -o SendEnv=ACCESS_TOKEN -o PubkeyAuthentication=no -o UserKnownHostsFile=./known_hosts -p 43022" git push aptible "$BRANCH:$REMOTE_BRANCH"
 
   aptible deploy --environment "$INPUT_ENVIRONMENT" \
                  --app "$INPUT_APP" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,7 @@ if [ "$INPUT_TYPE" == "git" ]; then
   fi
   export ACCESS_TOKEN=$(cat "$HOME/.aptible/tokens.json" | jq ".[\"$APTIBLE_AUTH_ROOT_URL\"]" -r)
   REMOTE_URL="root@$INPUT_GIT_REMOTE:$INPUT_ENVIRONMENT/$INPUT_APP.git"
-  git config --global --add safe.directory $PWD
+  git config --global --add safe.directory $GITHUB_WORKSPACE
   git remote add aptible ${REMOTE_URL}
   REMOTE_BRANCH="deploy-$(date "+%s")"
   GIT_SSH_COMMAND="ssh -o SendEnv=ACCESS_TOKEN -o PubkeyAuthentication=no -o UserKnownHostsFile=./known_hosts -p 43022" git push aptible "$BRANCH:$REMOTE_BRANCH"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,7 @@ if [ "$INPUT_TYPE" == "git" ]; then
   fi
   export ACCESS_TOKEN=$(cat "$HOME/.aptible/tokens.json" | jq ".[\"$APTIBLE_AUTH_ROOT_URL\"]" -r)
   REMOTE_URL="root@$INPUT_GIT_REMOTE:$INPUT_ENVIRONMENT/$INPUT_APP.git"
-  git config --global --add safe.directory /github/workspace
+  git config --global --add safe.directory $PWD
   git remote add aptible ${REMOTE_URL}
   REMOTE_BRANCH="deploy-$(date "+%s")"
   GIT_SSH_COMMAND="ssh -o SendEnv=ACCESS_TOKEN -o PubkeyAuthentication=no -o UserKnownHostsFile=./known_hosts -p 43022" git push aptible "$BRANCH:$REMOTE_BRANCH"


### PR DESCRIPTION
When moving from Xenial -> Noble, we upgraded Git to a version beyond 2.35.2. This introduces a Git protection that has [stricter repository ownership checks](https://github.blog/open-source/git/highlights-from-git-2-36/#stricter-repository-ownership-checks) that currently blocks the deploy-action from working. 

<img width="591" alt="Screenshot 2025-03-31 at 2 26 55 PM" src="https://github.com/user-attachments/assets/f6fa2e40-f1cc-4b65-9ac8-d82e64ac6019" />


Set `safe.directory= $GITHUB_WORKSPACE` in the GHA in order to circumvent this check.  

<img width="518" alt="Screenshot 2025-03-31 at 2 29 27 PM" src="https://github.com/user-attachments/assets/67d09f15-454e-4975-813f-690a7aa75f74" />


