### PR TITLE
Add OTP and lifetime.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:noble-curl
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    jq u2f-host git openssh-client \
+    jq u2f-host git openssh-client oathtool \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp/aptible-cli

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The following inputs can be used as `step.with` keys
 ### Optional input
 
 - `config_variables` - [configuration variables to set](https://www.aptible.com/docs/set-configuration-variables)
+- `otp_seed` - Aptible one-time password seed if required for user
+- `lifetime` - Aptible token lifetime
 
 > [!IMPORTANT]\
 > We do **not** recommend setting `config_variables` inside our github action
@@ -95,6 +97,8 @@ The following inputs can be used as `step.with` keys
   [configuration variables to set](https://www.aptible.com/docs/set-configuration-variables)
 - `docker_repository_url` - Provide docker repository URL which we can display
   in our web UI
+- `otp_seed` - Aptible one-time password seed if required for user
+- `lifetime` - Aptible token lifetime
 
 > [!IMPORTANT]\
 > We do **not** recommend setting `config_variables` inside our github action

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,13 @@ inputs:
     description: 'Aptible remote name'
     required: False
     default: aptible
+  otp_seed:
+    description: 'Aptible one-time password seed'
+    required: False
+  lifetime:
+    description: 'Aptible token lifetime'
+    required: False
+    default: 12h
 outputs:
   status:
     description: "The Success/Failure of the action"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,13 +21,17 @@ if [ -z "$INPUT_APP" ]; then
   exit 1
 fi
 
+export OTP="$([ -n "$INPUT_OTP_SEED" ] && oathtool -b --totp ${INPUT_OTP_SEED})"
+
 export APTIBLE_AUTH_ROOT_URL="$INPUT_AUTH_ROOT_URL"
 export APTIBLE_API_ROOT_URL="$INPUT_API_ROOT_URL"
 export APTIBLE_REMOTE="$INPUT_APTIBLE_REMOTE"
 
 aptible login \
   --email "$INPUT_USERNAME" \
-  --password "$INPUT_PASSWORD"
+  --password "$INPUT_PASSWORD" \
+  --otp-token "$OTP" \
+  --lifetime "$INPUT_LIFETIME"
 
 if ! APTIBLE_OUTPUT_FORMAT=json aptible apps | jq -e ".[] | select(.handle == \"$INPUT_APP\") | select(.environment.handle == \"$INPUT_ENVIRONMENT\")" > /dev/null; then
   echo "Could not find app $INPUT_APP in $INPUT_ENVIRONMENT" >&2


### PR DESCRIPTION
- Added `otp_seed` so we could have MFA on our bots and still have the action work
- Added `lifetime` since we were using 1 hour in our gh action and would prefer to keep shorter token